### PR TITLE
Fixing typo in convert_higher_order function

### DIFF
--- a/foliatools/folia2salt.py
+++ b/foliatools/folia2salt.py
@@ -692,7 +692,7 @@ def convert_higher_order(annotation, namespace, **kwargs):
             "{http://www.w3.org/2001/XMLSchema-instance}type": "saltCore:SMetaAnnotation",
                     "namespace": namespace,
                     "name": "comment/" + str(seqnr + 1),
-                    "value": "T::" + description.value
+                    "value": "T::" + comment.value
                 })
 
 


### PR DESCRIPTION
In trying to test out the newly added folia2salt converter, I was hit with the following error:

`UnboundLocalError: local variable 'description' referenced before assignment`

This looks to just be caused by a misnamed variable in the second loop of the convert_higher_order function, added in [this commit](https://github.com/proycon/foliatools/commit/e9e4ecceac9939e7ef5bb20b1b2e9cac0227b42e
). After changing `description.value` to `comment.value` in line 695, folia2salt works as expected. 