### PR TITLE
Folia2columns paragraphs

### DIFF
--- a/foliatools/folia2columns.py
+++ b/foliatools/folia2columns.py
@@ -153,15 +153,16 @@ def resize(s, i, spacing):
     #print '[' + s + ']', len(s), spacing[i]
     return s
 
-def processdir(d, outputfile = None):
+def processdir(d, outputfile = None, i = 0):
     print("Searching in  " + d, file=sys.stderr)
     for f in glob.glob(os.path.join(d, '*')):
         if f[-len(settings.extension) - 1:] == '.' + settings.extension:
-            process(f, outputfile)
+            process(f, outputfile, i)
+            i = i + 1
         elif settings.recurse and os.path.isdir(f):
-            processdir(f, outputfile)
+            i = processdir(f, outputfile, i)
 
-def process(filename, outputfile=None):
+def process(filename, outputfile=None, filesProcessed=0ho):
     try:
         print("Processing " + filename, file=sys.stderr)
         doc = folia.Document(file=filename)
@@ -195,7 +196,7 @@ def process(filename, outputfile=None):
                 else:
                     spacing.append(settings.nicespacing)
 
-        if settings.output_header:
+        if settings.output_header and not(outputfile and filesProcessed > 0): #avoid continuously reprinting header when printing multiple files to single file
 
             if settings.csv:
                 columns = [ '"' + x.upper()  + '"' for x in settings.columnconf ]

--- a/foliatools/folia2columns.py
+++ b/foliatools/folia2columns.py
@@ -278,9 +278,9 @@ def process(filename, outputfile=None, filesProcessed=0):
                         columns.append(w.annotation(folia.PhonAnnotation).cls)
                     except:
                         columns.append('-')
-                elif c == 'senid':
+                elif c == 'senid' and settings.unit == "word":
                     columns.append(w.sentence().id)
-                elif c == 'parid':
+                elif c == 'parid' and (settings.unit == "word" or settings.unit == "sentence"):
                     try:
                         columns.append(w.paragraph().id)
                     except:

--- a/foliatools/folia2columns.py
+++ b/foliatools/folia2columns.py
@@ -162,7 +162,7 @@ def processdir(d, outputfile = None, i = 0):
         elif settings.recurse and os.path.isdir(f):
             i = processdir(f, outputfile, i)
 
-def process(filename, outputfile=None, filesProcessed=0ho):
+def process(filename, outputfile=None, filesProcessed=0):
     try:
         print("Processing " + filename, file=sys.stderr)
         doc = folia.Document(file=filename)


### PR DESCRIPTION
I added an option to folia2columns to extract not just words, but also sentences and paragraphs into the column format, as this is useful for i.e. training sentence and paragraph embeddings. I have added it as a parameter -u with three options.  The default is word, so if no -u parameter is specified everything should work as before. I haven't extensively tested the sentence/paragraph option with all the column options, though. Using the n option (word number relative to sentence) will yield zeroes, and hopefully the other options still work at the sentence/paragraph level (I fixed a few obvious things like the paragraph and sentence ID column options).